### PR TITLE
allow carousel to scroll on 0 velocity

### DIFF
--- a/src/app/carousel/ngu-carousel/ngu-carousel.component.ts
+++ b/src/app/carousel/ngu-carousel/ngu-carousel.component.ts
@@ -244,7 +244,7 @@ export class NguCarousel
         });
       }
       hammertime.on('panend', (ev: any) => {
-        if (Math.abs(ev.velocity) > this.data.velocity) {
+        if (Math.abs(ev.velocity) >= this.data.velocity) {
           this.data.touch.velocity = ev.velocity;
           let direc = 0;
           if (!this.data.RTL) {


### PR DESCRIPTION
As a user I would expect that I can swipe the carousel slowly and it would snap to the next tile when I stop the touch interaction. This allows us to support that by setting `velocity: 0` in `NguCarouselConfig`. 