### PR TITLE
Add index.ts for code to build with Angular structure

### DIFF
--- a/projects/ngu-carousel/src/index.ts
+++ b/projects/ngu-carousel/src/index.ts
@@ -1,0 +1,5 @@
+/*
+ * Mimic Angular library structure.
+ */
+
+export * from './public-api';


### PR DESCRIPTION
The build system I use at my company basically requires an index.ts file. This also mimics a typical Angular Material structure for example https://github.com/angular/components/tree/master/src/material/card and https://github.com/angular/components/blob/master/src/material/card/index.ts.