### PR TITLE
Use trusted types compatible implementation for setting the carousel CSS

### DIFF
--- a/projects/ngu-carousel/src/lib/ngu-carousel/ngu-carousel.component.ts
+++ b/projects/ngu-carousel/src/lib/ngu-carousel/ngu-carousel.component.ts
@@ -735,7 +735,7 @@ export class NguCarousel<T> extends NguCarouselStore
       this.transform.all = this.inputs.grid.all * slide;
       slideCss = `${this.styleid} { transform: translate3d(${this.directionSym}${this.transform.all}px, 0, 0);`;
     }
-    this.carouselCssNode.innerHTML = slideCss;
+    this.carouselCssNode.textContent = slideCss;
   }
 
   /** this will trigger the carousel to load the items */


### PR DESCRIPTION
Prefer textContent over innerHTML when doing this.
I tried this out on a local application where I have this patch, and it seems to work just fine.

More details:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types
https://web.dev/trusted-types/
`Key Term: DOM-based cross-site scripting happens when data from a user controlled source (like user name, or redirect URL taken from the URL fragment) reaches a sink, which is a function like eval() or a property setter like .innerHTML, that can execute arbitrary JavaScript code.`