### PR TITLE
Update how isLast is set when data is updated

### DIFF
--- a/projects/ngu-carousel/src/lib/ngu-carousel/ngu-carousel.component.ts
+++ b/projects/ngu-carousel/src/lib/ngu-carousel/ngu-carousel.component.ts
@@ -196,7 +196,7 @@ export class NguCarousel<T> extends NguCarouselStore
         .pipe(takeUntil(this._intervalController$))
         .subscribe(data => {
           this.renderNodeChanges(data);
-          this.isLast = false;
+          this.isLast = this.isLast = this.pointIndex === this.currentSlide;
         });
     }
   }


### PR DESCRIPTION
Check if the current slide should be the last slide when `dataStream` is updated. This fixes an issue where the `dataStream` is updated but the carousel slides do not move. In the current state, `isLast` will incorrectly be set to false. With these changes, `isLast` will stay false if the carousel is still on the last slide after the data updates.

I've tested these changes on a local application with this patch. 