### PR TITLE
Prevent touchMove value of beeing infinite

### DIFF
--- a/projects/ngu-carousel/src/lib/ngu-carousel/ngu-carousel.component.ts
+++ b/projects/ngu-carousel/src/lib/ngu-carousel/ngu-carousel.component.ts
@@ -627,7 +627,8 @@ export class NguCarousel<T> extends NguCarouselStore
     let itemSpeed = this.speed;
     let translateXval = 0;
     let currentSlide = 0;
-    const touchMove = Math.ceil(this.dexVal / this.itemWidth);
+    let touchMove = Math.ceil(this.dexVal / this.itemWidth)
+    touchMove = isFinite(touchMove) ? touchMove : 0
     this._setStyle(this.nguItemsContainer.nativeElement, 'transform', '');
 
     if (this.pointIndex === 1) {


### PR DESCRIPTION
Prevent touchMove of being infinite. If it is infinite the current slide calculation on line 672 will return infinite and the swipe will  jump back to the previous slide.

Resolves issues: [310](https://github.com/uiuniversal/ngu-carousel/issues/310), [30](https://github.com/uiuniversal/ngu-carousel/issues/30), [64](https://github.com/uiuniversal/ngu-carousel/issues/64)
