### PR TITLE
Remove assignment to innerHTML

### DIFF
--- a/projects/ngu-carousel/src/lib/ngu-carousel/ngu-carousel.component.ts
+++ b/projects/ngu-carousel/src/lib/ngu-carousel/ngu-carousel.component.ts
@@ -484,7 +484,7 @@ export class NguCarousel<T> extends NguCarouselStore
   /** Used to reset the carousel */
   public reset(withOutAnimation?: boolean): void {
     withOutAnimation && (this.withAnim = false);
-    this.carouselCssNode.innerHTML = '';
+    this.carouselCssNode.textContent = '';
     this.moveTo(0);
     this._carouselPoint();
   }


### PR DESCRIPTION
Replaces the assignment of `''` to `innerHTML` with an assignment of `''` to `textContent` in order to resolve the CSP issue described in #339.

The goal of this line of code is just to remove the content of the `style` node that is referenced by the `carouselCssNode` property. So there's no real difference between using `textContent` and `innerHTML`. Both have the same effect. However, since `innerHTML` potentially allows unsafe DOM injections, it should be avoided (such as in cases like this) when it's not needed.

Resolves #339