### PR TITLE
chore: only support Angular 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Demo available [Here](https://ngu-carousel.netlify.app)
 
 | Angular Version | ngu-carousel Version                |
 | --------------- | ----------------------------------- |
-| Angular >= 13   | `npm i --save @ngu/carousel@latest` |
+| Angular >= 14   | `npm i --save @ngu/carousel@latest` |
+| Angular >= 13   | `npm i --save @ngu/carousel@5.0.0`  |
 | Angular >= 12   | `npm i --save @ngu/carousel@4.0.0`  |
 | Angular >= 10   | `npm i --save @ngu/carousel@3.0.2`  |
 | Angular = 9     | `npm i --save @ngu/carousel@2.1.0`  |

--- a/projects/ngu-carousel/README.md
+++ b/projects/ngu-carousel/README.md
@@ -12,7 +12,8 @@ Demo available [Here](https://ngu-carousel.netlify.app/)
 
 | Angular Version | ngu-carousel Version                |
 | --------------- | ----------------------------------- |
-| Angular >= 13   | `npm i --save @ngu/carousel@latest` |
+| Angular >= 14   | `npm i --save @ngu/carousel@latest` |
+| Angular >= 13   | `npm i --save @ngu/carousel@5.0.0`  |
 | Angular >= 12   | `npm i --save @ngu/carousel@4.0.0`  |
 | Angular >= 10   | `npm i --save @ngu/carousel@3.0.2`  |
 | Angular = 9     | `npm i --save @ngu/carousel@2.1.0`  |

--- a/projects/ngu-carousel/package.json
+++ b/projects/ngu-carousel/package.json
@@ -2,8 +2,8 @@
   "name": "@ngu/carousel",
   "version": "6.0.0",
   "peerDependencies": {
-    "@angular/common": "^13.0.0 || ^14.0.0",
-    "@angular/core": "^13.0.0 || ^14.0.0"
+    "@angular/common": "^14.0.0",
+    "@angular/core": "^14.0.0"
   },
   "dependencies": {
     "tslib": "2.4.0"


### PR DESCRIPTION
Hello,

### Problem

I think I did a mistake when I tested the lib on my previous PR about updating to Angular 14 https://github.com/uiuniversal/ngu-carousel/pull/379.

What I did was:

- Testing the lib compiled with `Angular 13` on an `Angular 13` demo app
- Testing the lib compiled with `Angular 14` on an `Angular 14` demo app

What I did not:

- Testing the lib compiled with `Angular 14` on an `Angular 13` demo app

And it seems that using a compiled version of the lib with `Angular 14` isn't compatible with an `Angular 13` app.

```
TypeError: Cannot create property 'message' on string 'D:\GitHub\Angular13Project\node_modules\@ngu\carousel\fesm2015\ngu-carousel.mjs: This application depends upon a library published using Angular version 14.1.3, which requires Angular version 14.0.0 or newer to work correctly.
Consider upgrading your application to use a more recent version of Angular.
  82 | }
  83 | NguCarouselItemDirective.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "14.1.3", ngImport: i0, type: NguCarouselItemDirective, deps: [], target: i0.ɵɵFactoryTarget.Directive });
> 84 | NguCarouselItemDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "14.1.3", type: NguCarouselItemDirective, selector: "[NguCarouselItem]", ngImport: i0 });
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^39m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^39m^^^^^^^^^^^^^^^^^^^
```

### Changes

This PR does:

- Only support Angular 14

### Other solution

Another solution could be to compile the lib with `Angular 13` but still support `Angular 14` (`^13.0.0 || ^14.0.0`), but I did not test it. If you wish, I can test it tomorrow. The down side would be to have an `Angular 13` version of the repo on another branche. Maybe there's another solution, I'm not familiar enough with compiled version compatibility of libs.

I'm sorry, I wasn't expecting that behavior 😢.
I don't know what's the best solution, remove the current 6.0 and make a new one or bump to 6.1 (or any version you want).

Have a good day/night.

@santoshyadavdev 