### PR TITLE
build(lib): fix dependencies

### DIFF
--- a/libs/ngu/carousel/package.json
+++ b/libs/ngu/carousel/package.json
@@ -3,7 +3,13 @@
   "version": "7.1.1",
   "peerDependencies": {
     "@angular/common": "^15.0.0",
-    "@angular/core": "^15.0.0"
+    "@angular/core": "^15.0.0",
+    "@angular/animations": "^15.0.0",
+    "rxjs": "^7.0.0",
+    "zone.js": "^0.11.4"
+  },
+  "optionalDependencies": {
+    "hammerjs": "^2.0.0"
   },
   "dependencies": {
     "tslib": "2.4.1"

--- a/libs/ngu/carousel/project.json
+++ b/libs/ngu/carousel/project.json
@@ -8,7 +8,8 @@
     "build": {
       "executor": "@nrwl/angular:package",
       "options": {
-        "project": "libs/ngu/carousel/ng-package.json"
+        "project": "libs/ngu/carousel/ng-package.json",
+        "updateBuildableProjectDepsInPackageJson": false
       },
       "configurations": {
         "production": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "hammerjs": "2.0.8",
     "rxjs": "7.8.0",
     "tslib": "2.4.1",
-    "zone.js": "0.12.0"
+    "zone.js": "0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "15.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10341,6 +10341,7 @@ html-void-elements@^1.0.0:
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
 
 "html-webpack-plugin-4@npm:html-webpack-plugin@^4", html-webpack-plugin@^4.0.0:
+  name html-webpack-plugin-4
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz#76fc83fa1a0f12dd5f7da0404a54e2699666bc12"
   integrity sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==
@@ -10356,6 +10357,7 @@ html-void-elements@^1.0.0:
     util.promisify "1.0.0"
 
 "html-webpack-plugin-5@npm:html-webpack-plugin@^5", html-webpack-plugin@^5.0.0, html-webpack-plugin@^5.5.0:
+  name html-webpack-plugin-5
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz#c3911936f57681c1f9f4d8b68c158cd9dfe52f50"
   integrity sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==
@@ -18126,12 +18128,12 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-zone.js@0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.12.0.tgz#a4a6e5fab6d34bd37d89c77e89ac2e6f4a3d2c30"
-  integrity sha512-XtC+I5dXU14HrzidAKBNMqneIVUykLEAA1x+v4KVrd6AUPWlwYORF8KgsVqvgdHiKZ4BkxxjvYi/ksEixTPR0Q==
+zone.js@0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.11.4.tgz#0f70dcf6aba80f698af5735cbb257969396e8025"
+  integrity sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==
   dependencies:
-    tslib "^2.3.0"
+    tslib "^2.0.0"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Hello,

Related to https://github.com/uiuniversal/ngu-carousel/issues/437

I've spotted some problems that appeared with the migration to nx.

Since you are now using nx and `@nrwl/angular:package`, when you build the lib, it will add all "used" detected dependencies in the built `package.json`.

Resulting to something similar to this in `package.json` (and fixed version numbers):

```json
{
  "name": "@ngu/carousel",
  "version": "7.1.1",
  "peerDependencies": {
    "@angular/common": "^15.0.0",
    "@angular/core": "^15.0.0",
    "@angular/animations": "15.0.2",
    "rxjs": "7.8.0",
    "hammerjs": "2.0.8",
    "@angular/platform-browser-dynamic": "15.2.6",
    "core-js": "3.30.1",
    "zone.js": "0.12.0"
  },
...
```

There is unused deps and fixed versions.

If we want to prevent nx from adding all detected deps automatically, we need to setup `"updateBuildableProjectDepsInPackageJson": false` in the `project.json` of the lib.

However, since it added all used deps in the built version, we can notice that there is some missing `peerDependencies` in non-built `package.json`.

Diving in the code, I also noticed that hammerjs isn't loaded if we don't need it, that's why I choose to put it in `optionalDependencies`.

The final deps in the non-built `package.json`:

```json
  "peerDependencies": {
    "@angular/common": "^15.0.0",
    "@angular/core": "^15.0.0",
    "@angular/animations": "^15.0.0",
    "rxjs": "^7.0.0",
    "zone.js": "^0.11.4"
  },
  "optionalDependencies": {
    "hammerjs": "^2.0.0"
  },
```

___
(Not related to the lib, but the repo)

I also detected by running `npm install` that `zone.js` `0.12.0` seems not supported with `@storybook/angular@6.5.16` resulting to this:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: ngu-carousel-example@7.1.1
npm ERR! Found: zone.js@0.12.0
npm ERR! node_modules/zone.js
npm ERR!   zone.js@"0.12.0" from the root project
npm ERR!   peer zone.js@"~0.11.4 || ~0.12.0 || ~0.13.0" from @angular/core@15.2.6
npm ERR!   node_modules/@angular/core
npm ERR!     @angular/core@"15.2.6" from the root project
npm ERR!     peer @angular/core@">=6.0.0" from @storybook/angular@6.5.16
npm ERR!     node_modules/@storybook/angular
npm ERR!       dev @storybook/angular@"^6.5.15" from the root project
npm ERR!     6 more (@angular/compiler, @angular/animations, ...)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer zone.js@"^0.8.29 || ^0.9.0 || ^0.10.0 || ^0.11.0" from @storybook/angular@6.5.16
npm ERR! node_modules/@storybook/angular
npm ERR!   dev @storybook/angular@"^6.5.15" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

I changed the version to `0.11.4` which is compatible with `Angular` `^15.2.0` and `@storybook/angular@6.5.16`.

cc @santoshyadavdev 