### PR TITLE
Add GitHub action to auto-close inactive issues

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -1,0 +1,20 @@
+name: 'Close Stale Issues'
+
+on:
+  schedule:
+    - cron: '0 10 * * 5' # Scheduled to run every Friday at 12pm CET
+
+jobs:
+  stale-issue-handler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Mark and close stale issues
+        uses: actions/stale@v9
+        with:
+          days-before-stale: 180
+          days-before-close: 0
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity for 6 months. It will be closed if no further activity occurs. Thank you for your contributions.'
+          close-issue-message: 'Closing this issue due to no activity for 6 months.'
+          stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity for 6 months. It will be closed if no further activity occurs. Thank you for your contributions.'
+          close-pr-message: 'Closing this PR due to no activity for 6 months.'


### PR DESCRIPTION
Adds a new GitHub action to automatically close issues older than 6 months due to inactivity and comment on them every Friday at 12pm CET.
- **Scheduling**: Configures the action to run on a schedule, specifically every Friday at 12pm CET, using a cron job.
- **Issue Handling**: Utilizes the `actions/stale` action to automatically mark issues as stale after 180 days of inactivity and then immediately close them.
- **Messaging**: Before closing, posts a comment on the stale issues and pull requests to inform contributors of the closure due to inactivity, with separate messages for issues and pull requests.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/uiuniversal/ngu-carousel?shareId=c8edbcf3-36e5-46a2-902c-43b44013b4d7).