### PR TITLE
Add workflow for branch age notification

### DIFF
--- a/.github/workflows/branch-notification.yml
+++ b/.github/workflows/branch-notification.yml
@@ -24,7 +24,21 @@ jobs:
             });
             if (oldBranches.length > 0) {
               console.log(`Found ${oldBranches.length} branches older than 180 days.`);
-              // Add notification logic here
+              for (const branch of oldBranches) {
+                const { data: commits } = await github.repos.listCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: branch.name,
+                  per_page: 1,
+                });
+                const commitAuthorEmail = commits[0].commit.author.email;
+                await github.repos.createCommitComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: commits[0].sha,
+                  body: `This branch is more than 180 days old. Consider deleting or archiving it.`
+                });
+              }
             } else {
               console.log('No branches older than 180 days were found.');
             }

--- a/.github/workflows/branch-notification.yml
+++ b/.github/workflows/branch-notification.yml
@@ -1,0 +1,30 @@
+name: Branch Age Notification
+
+on:
+  schedule:
+    - cron: '0 12 * * 5' # Run every Friday at 12pm CET
+
+jobs:
+  branch-age-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for branches older than 180 days
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: branches } = await github.repos.listBranches({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const oldBranches = branches.filter(branch => {
+              const lastCommitDate = new Date(branch.commit.commit.author.date);
+              const daysOld = (new Date() - lastCommitDate) / (1000 * 60 * 60 * 24);
+              return daysOld > 180;
+            });
+            if (oldBranches.length > 0) {
+              console.log(`Found ${oldBranches.length} branches older than 180 days.`);
+              // Add notification logic here
+            } else {
+              console.log('No branches older than 180 days were found.');
+            }


### PR DESCRIPTION
Adds a new GitHub Actions workflow to send notifications for branches older than 180 days.
- **Workflow Configuration**: Introduces a new file `.github/workflows/branch-notification.yml` named 'Branch Age Notification'.
- **Schedule Trigger**: Configures the workflow to run weekly, specifically every Friday at 12pm CET.
- **Branch Age Check Job**: Adds a job that checks for branches older than 180 days using `actions/github-script@v6`.
- **Notification Logic Placeholder**: Includes a placeholder for adding notification logic for branches identified as older than 180 days.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/uiuniversal/ngu-carousel?shareId=c25f0e2c-0419-49ed-b8e8-95bf9e72c41f).