### PR TITLE
Add GitHub Action to delete stale branches

### DIFF
--- a/.github/workflows/delete-stale-branches.yml
+++ b/.github/workflows/delete-stale-branches.yml
@@ -1,0 +1,17 @@
+name: Delete Stale Branches
+
+on:
+  schedule:
+    - cron: '0 12 * * 5' # Run every Friday at 12 pm CET
+
+jobs:
+  delete_stale_branches:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Delete branches older than 100 days
+        uses: dev-drprasad/delete-older-branches@v0.3.1
+        with:
+          max-age: '100d'
+          delete-merged-branches: 'true'
+          exclude-branches: 'master,main,develop'


### PR DESCRIPTION
This pull request introduces a new GitHub Action to automatically delete stale branches in the `uiuniversal/ngu-carousel` repository.

- **Schedules the action to run every Friday at 12 pm CET**, ensuring that the repository maintenance does not interfere with the regular workflow during the weekdays.
- **Targets branches older than 100 days** for deletion, helping to keep the repository clean and manageable by removing outdated and potentially obsolete branches.
- **Excludes critical branches** such as `master`, `main`, and `develop` from being deleted, safeguarding the main lines of development from accidental removal.
- **Utilizes the latest version of GitHub Actions** and the `dev-drprasad/delete-older-branches@v0.3.1` action for efficient and reliable branch deletion.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/uiuniversal/ngu-carousel?shareId=b5d69b88-b32b-4dd8-8bc5-d1769ee83490).