### PR TITLE
chore: remove version older than 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,6 @@ Demo available [Here](https://ngu-carousel.netlify.app)
 | Angular >= 19            | `npm i --save @ngu/carousel@19`    |
 | Angular >= 18            | `npm i --save @ngu/carousel@18`    |
 | Angular >= 17            | `npm i --save @ngu/carousel@9.0.0` |
-| Angular >= 16 standalone | `npm i --save @ngu/carousel@8.0.0` |
-| Angular >= 16            | `npm i --save @ngu/carousel@7.2.0` |
-| Angular >= 15            | `npm i --save @ngu/carousel@7.0.0` |
-| Angular >= 14            | `npm i --save @ngu/carousel@6.0.0` |
-| Angular >= 13            | `npm i --save @ngu/carousel@5.0.0` |
-| Angular >= 12            | `npm i --save @ngu/carousel@4.0.0` |
-| Angular >= 10            | `npm i --save @ngu/carousel@3.0.2` |
-| Angular = 9              | `npm i --save @ngu/carousel@2.1.0` |
-| Angular < 9              | `npm i --save @ngu/carousel@1.5.5` |
 
 ## Usage
 


### PR DESCRIPTION
This pull request updates the compatibility table in the `README.md` file by removing installation instructions for older Angular versions. The change streamlines the documentation to focus only on recent Angular releases.

Documentation update:

* Removed installation instructions for Angular versions lower than 17 from the compatibility table in `README.md`, making the documentation more concise and focused on current supported versions.